### PR TITLE
Add Slack notification to help-p1 when action fails

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -85,3 +85,24 @@ jobs:
           keep_latest: 144
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Slack Notification
+        if: failure()
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Security artifacts generation result: ${{ job.status }}\nhttps://github.com/fleetdm/nvd/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_P1_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Copied from [fleetdm/nvd](https://github.com/fleetdm/nvd):
https://github.com/fleetdm/nvd/blob/dc46bfca2435e11df65b1ec9e7ef579e71904a0a/.github/workflows/generate.yml#L76-L95

@lukeheath We'd need `secrets.SLACK_G_HELP_P1_WEBHOOK_URL` also defined on this repository.