### PR TITLE
Add goval-dictionary sqlite build + xz for Amazon Linux 1/2/2022/2023

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -53,6 +53,14 @@ jobs:
           ref: main
           path: fleet
 
+      - name: Checkout goval-dictionary
+        uses: actions/checkout@v4
+        with:
+          repository: vulsio/goval-dictionary
+          fetch-depth: 1
+          ref: adcb4dc66908aa84a0aabcd376af0e6e677ea2fd
+          path: goval-dictionary
+
       - name: Setup Go
         uses: actions/setup-go@v4.1.0
         with:
@@ -64,6 +72,16 @@ jobs:
           cd fleet
           go mod download
           go run cmd/cve/generate.go --db_dir ./cvefeed --debug
+
+      - name: Generate goval-dictionary sqlite files
+        run: |
+          cd goval-dictionary
+          make build
+          ./goval-dictionary fetch amazon 1 --dbpath ../fleet/cvefeed/amzn_01.sqlite3
+          ./goval-dictionary fetch amazon 2 --dbpath ../fleet/cvefeed/amzn_02.sqlite3
+          ./goval-dictionary fetch amazon 2022 --dbpath ../fleet/cvefeed/amzn_2022.sqlite3
+          ./goval-dictionary fetch amazon 2023 --dbpath ../fleet/cvefeed/amzn_2023.sqlite3
+          xz ../fleet/cvefeed/*.sqlite3
             
       - name: Current date
         id: date


### PR DESCRIPTION
This adds pulls for Amazon Linux via goval-dictionary. QA'd in https://github.com/iansltx/vulnerabilities/actions/runs/10501203506 -> https://github.com/iansltx/vulnerabilities/releases/tag/cve-202408220322. We can do *.sqlite3 on the xz compression as we don't have any sqlites in the archive yet.

Open question of whether this goes here or the `nvd` repo; I can rebuild this over there if needed.