### PR TITLE
increase timeout for clean runs

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build:  
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
changes to NVD's API is resulting in increases error rates.  Increasing the timeout on the generate-cve job  for use with a 'clean' run.