### PR TITLE
Alert when release > 1 hr old

### DIFF
--- a/.github/workflows/cve-freshness-check.yml
+++ b/.github/workflows/cve-freshness-check.yml
@@ -1,0 +1,58 @@
+name: CVE Freshness Check
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '15,45 * * * *'
+  workflow_dispatch:
+    
+permissions:
+  contents: read
+
+jobs:
+  pull_latest_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get latest release
+        id: get_latest_release
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/${{ github.repository }}/releases/latest
+
+      - name: Check release time
+        run: |
+          current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          release_time=$(echo "${{ steps.get_latest_release.outputs.data }}" | jq -r .published_at)
+          echo "Current time: $current_time"
+          echo "Release time: $release_time"
+          current_time_epoch=$(date -d "$current_time" +%s)
+          release_time_epoch=$(date -d "$release_time" +%s)
+          time_diff=$((current_time_epoch - release_time_epoch))
+          echo "Time difference: $time_diff seconds"
+          echo "::set-output name=time_diff::$time_diff"
+
+      - name: Send Slack message if release > 3600 seconds
+        if: steps.check_release_time.outputs.time_diff > 3600
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<!subteam^S086VL144TU>, security artifacts generation result: ${{ job.status }}\nhttps://github.com/fleetdm/vulnerabilities/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_P1_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -117,24 +117,3 @@ jobs:
           keep_latest: 144
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Slack Notification
-        if: failure()
-        uses: slackapi/slack-github-action@v1.18.0
-        with:
-          payload: |
-            {
-              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Security artifacts generation result: ${{ job.status }}\nhttps://github.com/fleetdm/vulnerabilities/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_P2_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Deleted original alert from generate-cve pipeline as this alert is too sensitive to transient errors.
Added new pipeline to check if release is older than 1 hour. This is a better indicator of an error.

https://github.com/fleetdm/fleet/issues/22518