### PR TITLE
Explicitly specify step id for reference in later steps

### DIFF
--- a/.github/workflows/cve-freshness-check.yml
+++ b/.github/workflows/cve-freshness-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get latest release
         id: get_latest_release
@@ -27,6 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check release time
+        id: check_release_time
         run: |
           current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           release_time=$(echo '${{ fromJson(steps.get_latest_release.outputs.data).published_at }}')


### PR DESCRIPTION
Silencing warning from github actions extension.
<img width="552" alt="Screenshot 2025-02-21 at 4 28 31 PM" src="https://github.com/user-attachments/assets/8098a0fe-6348-44bb-9738-7276297b6ac2" />
