### PR TITLE
Improve messaging around failures

### DIFF
--- a/.github/workflows/cve-freshness-check.yml
+++ b/.github/workflows/cve-freshness-check.yml
@@ -44,13 +44,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "text": "failure\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!subteam^S086VL144TU>, security artifacts generation result: ${{ job.status }}\nhttps://github.com/fleetdm/vulnerabilities/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+                    "text": "<!subteam^S086VL144TU>, security artifacts generation result: failure\nhttps://github.com/fleetdm/vulnerabilities/actions/runs/${{  github.run_id }}\nSee https://github.com/fleetdm/vulnerabilities/actions?query=is%3Afailure for failure details\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
                   }
                 }
               ]


### PR DESCRIPTION
The `job.status` is the status of the freshness check, which will always `success`. Change it to a hard coded `failure` to avoid confusion. Also link to the workflow runs page filtered on "failure" to provide a quick link to diagnose the issue.