### PR TITLE
Match go version to the one currently used in Fleet

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-go@v4.1.0
         with:
           cache: false
-          go-version: '^1.23.4'
+          go-version: '^1.24.2'
 
       - name: Generate NVD Feeds
         run: |


### PR DESCRIPTION
Currently the newer go version gets downloaded automatically in a subsequent step, but this will save a bit of duplicated time/effort due to no longer downloading the wrong version first.