### PR TITLE
Add RHEL OSV feed generation

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -108,13 +108,13 @@ jobs:
 
       - name: Generate OSV Ubuntu Artifacts
         run: |
-          echo "=== Generating OSV Artifacts for Ubuntu ===" 
+          echo "=== Generating OSV Artifacts for Ubuntu ==="
           cd $GITHUB_WORKSPACE/fleet/cmd/osv-processor
-          
+
           # Sync OSV data from Canonical (shallow clone with rolling window)
           chmod +x sync-and-detect-changes.sh
           ./sync-and-detect-changes.sh
-          
+
           # Generate artifacts for ALL Ubuntu versions (auto-detected)
           # Includes full artifacts + today's and yesterday's deltas
           go run . \
@@ -122,9 +122,26 @@ jobs:
             --output $GITHUB_WORKSPACE/fleet/cvefeed \
             --changed-files-today changed_files_today.txt \
             --changed-files-yesterday changed_files_yesterday.txt
-          
+
           echo "OSV artifacts generated successfully"
           ls -lh $GITHUB_WORKSPACE/fleet/cvefeed/osv-ubuntu-*.json.gz
+
+      - name: Generate OSV RHEL Artifacts
+        run: |
+          echo "=== Generating OSV Artifacts for RHEL ==="
+          curl -sL "https://storage.googleapis.com/osv-vulnerabilities/Red%20Hat/all.zip" \
+            -o /tmp/rhel-osv.zip
+          unzip -q /tmp/rhel-osv.zip -d /tmp/rhel-osv
+
+          cd $GITHUB_WORKSPACE/fleet/cmd/osv-processor
+          go run . \
+            --platform rhel \
+            --input /tmp/rhel-osv \
+            --output $GITHUB_WORKSPACE/fleet/cvefeed \
+            --versions "7,8,9,10"
+
+          echo "RHEL OSV artifacts generated successfully"
+          ls -lh $GITHUB_WORKSPACE/fleet/cvefeed/osv-rhel-*.json.gz
 
       - name: Validate NVD Feeds
         run: |


### PR DESCRIPTION
## Summary

Adds a single workflow step to `generate-cve.yml` that downloads Red Hat's OSV data from GCS and runs the osv-processor to generate RHEL artifacts.

## Changes

One new step in `.github/workflows/generate-cve.yml`:
1. Downloads `https://storage.googleapis.com/osv-vulnerabilities/Red%20Hat/all.zip` (23MB)
2. Runs `osv-processor --platform rhel --versions "7,8,9,10"` 
3. Outputs `osv-rhel-{7,8,9,10}-YYYY-MM-DD.json.gz` into `fleet/cvefeed/`

The existing release step already uploads `fleet/cvefeed/*`, so the new artifacts are published automatically.

## Dependencies

- Requires fleetdm/fleet#43183 to be merged first (adds `--platform rhel` support to `cmd/osv-processor`)

## Expected output

Each run will produce 4 new artifacts alongside existing ones:
| Artifact | Packages | CVEs | Size |
|----------|----------|------|------|
| `osv-rhel-7-YYYY-MM-DD.json.gz` | ~4,000 | ~4,600 | ~335KB |
| `osv-rhel-8-YYYY-MM-DD.json.gz` | ~6,800 | ~6,900 | ~1.1MB |
| `osv-rhel-9-YYYY-MM-DD.json.gz` | ~4,400 | ~5,900 | ~1.3MB |
| `osv-rhel-10-YYYY-MM-DD.json.gz` | ~1,900 | ~1,000 | ~252KB |