### PR TITLE
Authenticate GitHub Go client in Generate NVD Feeds step

### DIFF
--- a/.github/workflows/generate-cve.yml
+++ b/.github/workflows/generate-cve.yml
@@ -60,6 +60,8 @@ jobs:
           go-version: "^1.25.7"
 
       - name: Generate NVD Feeds
+        env:
+          NETWORK_TEST_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd fleet
           go mod download


### PR DESCRIPTION
## Summary

The Go seed-fetch in `server/vulnerabilities/nvd/cve.go` calls `fleethttp.NewGithubClient()`, which only authenticates when the `NETWORK_TEST_GITHUB_TOKEN` env var is set (see `pkg/fleethttp/fleethttp.go:130` in `fleetdm/fleet`). The `Generate NVD Feeds` step only exposes `GH_TOKEN`, so the call to `GET /repos/fleetdm/vulnerabilities/releases` is anonymous and falls under GitHub's 60/hr per-IP cap shared across all GitHub Actions runners.

When the cap is exhausted (which happens intermittently as the runner pool churns), the seed download 403s, the workflow falls into `Continuing with full NVD Sync`, and the validate spot-check for `CVE-2025-0938` panics because the full-sync path produces fewer CPE matches than the seed-based path preserves.

Wiring `secrets.GITHUB_TOKEN` to `NETWORK_TEST_GITHUB_TOKEN` puts that request under the workflow's authenticated 5,000/hr quota and stops the fallback.

Example failing run: https://github.com/fleetdm/vulnerabilities/actions/runs/25226854671/job/73972413678

## Test plan

- [ ] Next scheduled `Generate CVE` run completes in ~12 min (seed path) instead of ~31 min (full-sync fallback)
- [ ] No `Failed to download latest release. Continuing with full NVD Sync` warnings appear in the `Generate NVD Feeds` step logs